### PR TITLE
# use PhantomJS for integration testing

### DIFF
--- a/ndr_error.gemspec
+++ b/ndr_error.gemspec
@@ -31,6 +31,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'test-unit', '~> 3.0'
   s.add_development_dependency 'mocha'
 
+  s.add_development_dependency 'capybara'
+  s.add_development_dependency 'capybara-screenshot'
+  s.add_development_dependency 'poltergeist', '>= 1.8.0'
+
   s.add_development_dependency 'rubocop', '0.36.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'ndr_dev_support', '~> 1.1', '>= 1.1.3'

--- a/test/dummy/app/controllers/disaster_controller.rb
+++ b/test/dummy/app/controllers/disaster_controller.rb
@@ -1,5 +1,8 @@
 # Some application logic that we should be able to log failures from:
 class DisasterController < ApplicationController
+  def no_panic
+  end
+
   def cause
     fail params[:message]
   end

--- a/test/dummy/app/views/disaster/no_panic.html.erb
+++ b/test/dummy/app/views/disaster/no_panic.html.erb
@@ -1,0 +1,1 @@
+<b>There is nothing to fear!</b>

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -10,6 +10,10 @@
 
 <h1>This is the Dummy App's layout file!</h1>
 
+<% flash.each do |key, value| %>
+  <%= content_tag(:p, value, klass: key) %>
+<% end %>
+
 <%= yield %>
 
 </body>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -2,4 +2,6 @@ Rails.application.routes.draw do
   mount NdrError::Engine => '/fingerprinting'
 
   get '/:controller(/:action(/:id))'
+
+  root to: 'disaster#no_panic'
 end

--- a/test/integration/error_logging_test.rb
+++ b/test/integration/error_logging_test.rb
@@ -59,10 +59,10 @@ class ErrorLoggingTest < ActionDispatch::IntegrationTest
   def assert_application_fails_gracefully(message, log_count = 1)
     assert_difference('NdrError::Log.count', log_count) do
       # get "/fingerprinting/errors/fail/#{message}?raise=true"
-      get "/disaster/cause/?message=#{message}"
+      visit "/disaster/cause/?message=#{message}"
 
-      assert response.body.include? 'This is the 500 page for DummyApp.'
-      assert_equal 500, response.status
+      assert page.body.include? 'This is the 500 page for DummyApp.'
+      assert_equal 500, page.status_code
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,6 +19,101 @@ if ActiveSupport::TestCase.method_defined?(:fixture_path=)
   ActiveSupport::TestCase.fixture_path = File.expand_path('../fixtures', __FILE__)
 end
 
+# Capybara configuration:
+require 'capybara/rails'
+require 'capybara/poltergeist'
+
+require 'capybara-screenshot'
+if defined?(MiniTest)
+  require 'capybara-screenshot/minitest'
+else
+  require 'capybara-screenshot/testunit'
+end
+
+Capybara.register_driver :poltergeist do |app|
+  options = {
+    # debug: true, # Uncomment for more verbose
+    # inspector: true, # DEBUGGING suppport.
+    phantomjs_options: ['--proxy-type=none'],
+    timeout: 60
+  }
+
+  Capybara::Poltergeist::Driver.new(app, options)
+end
+
+# Ensure that we are always using poltergeist:
+Capybara.default_driver    = :poltergeist
+Capybara.javascript_driver = :poltergeist
+
+# Save screenshots to tmp/capybara/... on integration test error/failure:
+Capybara::Screenshot.register_driver(:poltergeist) do |driver, path|
+  driver.render(path, full: true) # Take full-height screenshots
+end
+
+module Capybara
+  class Session
+    # Variant of Capybara's #within_window method, that doesn't return
+    # to the preview window on an exception. This allows us to screenshot
+    # a popup automatically if a test errors/fails whilst it has focus.
+    def within_screenshot_compatible_window(window_or_proc)
+      original = current_window
+
+      case window_or_proc
+      when Capybara::Window
+        switch_to_window(window_or_proc) unless original == window_or_proc
+      when Proc
+        switch_to_window { window_or_proc.call }
+      else
+        fail ArgumentError, 'Unsupported window type!'
+      end
+
+      scopes << nil
+      yield
+      @scopes.pop
+      switch_to_window(original)
+    end
+  end
+
+  module CustomDSL
+    delegate :within_screenshot_compatible_window, to: :page
+  end
+end
+
+module ActionDispatch
+  class IntegrationTest
+    # Make the Capybara DSL available in all integration tests
+    include Capybara::DSL
+    include Capybara::CustomDSL
+
+    include Capybara::Screenshot::MiniTestPlugin if defined?(MiniTest)
+  end
+end
+
+# Capybara starts another rails application in a new thread
+# to test against. For transactional fixtures to work, we need
+# to share the database connection between threads.
+#
+# Multiple connections:
+#   We authenticate users by using their credentials to attempt
+#   a database connection. Normally, when a user's connection is
+#   added to the pool, any other connections of theirs are
+#   automatically purged, to prevent spurious simultaneous logins.
+#   In the (integration) test environment, this would purge the
+#   primary test connection, so this behaviour is disabled.
+#
+# Monkey patch from: https://gist.github.com/josevalim/470808
+#
+module ActiveRecord
+  class Base
+    mattr_accessor :shared_connection
+
+    def self.connection
+      shared_connection || retrieve_connection
+    end
+  end
+end
+ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection
+
 module ActiveSupport
   # Add additional helper methods for creating logged errors
   class TestCase


### PR DESCRIPTION
Adds `capybara`, `capybara-screenshot`, and `poltergeist` as development dependencies.