### PR TITLE
Implement client error logging

### DIFF
--- a/app/assets/javascripts/ndr_error/client_errors.js
+++ b/app/assets/javascripts/ndr_error/client_errors.js
@@ -1,0 +1,36 @@
+var NdrError = {
+  url: function() {
+    var origin = window.location.origin;
+
+    // IE doesn't support `location.origin`:
+    origin = origin || (
+      window.location.protocol + '//' +
+      window.location.hostname +
+      (window.location.port ? ':' + window.location.port: '')
+    );
+
+    // TODO: '/fingerprinting' is configureable, use
+    // client_errors_url helper?
+    return origin + '/fingerprinting/client_errors';
+  },
+
+  notify: function(message, source, lineno, colno, error) {
+    jQuery.post(NdrError.url(), {
+      'client_error': {
+        'message': message,
+        'source':  source,
+        'lineno':  lineno,
+        'colno':   colno,
+        'stack':   error && error.stack,
+        'window.width':  window.innerWidth,
+        'window.height': window.innerHeight,
+        'screen.width':  window.screen.width,
+        'screen.height': window.screen.height
+      }
+    })
+  }
+};
+
+window.onerror = function(message, source, lineno, colno, error) {
+  NdrError.notify(message, source, lineno, colno, error);
+}

--- a/app/assets/javascripts/ndr_error/ndr_error.js
+++ b/app/assets/javascripts/ndr_error/ndr_error.js
@@ -46,6 +46,7 @@ jQuery(function() {
     jQuery('.badge').tooltip();
 
     $searchField.keydown(function(event) {
+      adfgkljh
       // <ENTER> will submit the search form.
       if (event.keyCode == 13) {
         this.form.submit();
@@ -58,3 +59,15 @@ jQuery(function() {
     });
   })();
 });
+
+window.onerror = function(message, source, lineno, colno, error) {
+  jQuery.post('client_errors/', {
+    'path':    window.location.href,
+    'message': message,
+    'source':  source,
+    'lineno':  lineno,
+    'colno':   colno,
+    'error':   error,
+    'stack':   error && error.stack
+  })
+}

--- a/app/assets/javascripts/ndr_error/ndr_error.js
+++ b/app/assets/javascripts/ndr_error/ndr_error.js
@@ -13,6 +13,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require ndr_error/bootstrap/bootstrap
+//= require ndr_error/client_errors
 
 jQuery(function() {
   // Backtrace toggling:
@@ -59,15 +60,3 @@ jQuery(function() {
     });
   })();
 });
-
-window.onerror = function(message, source, lineno, colno, error) {
-  jQuery.post('client_errors/', {
-    'client_error': {
-      'message': message,
-      'source':  source,
-      'lineno':  lineno,
-      'colno':   colno,
-      'stack':   error && error.stack
-    }
-  })
-}

--- a/app/assets/javascripts/ndr_error/ndr_error.js
+++ b/app/assets/javascripts/ndr_error/ndr_error.js
@@ -46,7 +46,7 @@ jQuery(function() {
     jQuery('.badge').tooltip();
 
     $searchField.keydown(function(event) {
-      adfgrdfgkljh
+      wenewnew
       // <ENTER> will submit the search form.
       if (event.keyCode == 13) {
         this.form.submit();

--- a/app/assets/javascripts/ndr_error/ndr_error.js
+++ b/app/assets/javascripts/ndr_error/ndr_error.js
@@ -60,3 +60,15 @@ jQuery(function() {
     });
   })();
 });
+
+window.onerror = function(message, source, lineno, colno, error) {
+  jQuery.post('client_errors/', {
+    'client_error': {
+      'message': message,
+      'source':  source,
+      'lineno':  lineno,
+      'colno':   colno,
+      'stack':   error && error.stack
+    }
+  })
+}

--- a/app/assets/javascripts/ndr_error/ndr_error.js
+++ b/app/assets/javascripts/ndr_error/ndr_error.js
@@ -46,7 +46,7 @@ jQuery(function() {
     jQuery('.badge').tooltip();
 
     $searchField.keydown(function(event) {
-      adfgkljh
+      adfgrdfgkljh
       // <ENTER> will submit the search form.
       if (event.keyCode == 13) {
         this.form.submit();
@@ -62,12 +62,12 @@ jQuery(function() {
 
 window.onerror = function(message, source, lineno, colno, error) {
   jQuery.post('client_errors/', {
-    'path':    window.location.href,
-    'message': message,
-    'source':  source,
-    'lineno':  lineno,
-    'colno':   colno,
-    'error':   error,
-    'stack':   error && error.stack
+    'client_error': {
+      'message': message,
+      'source':  source,
+      'lineno':  lineno,
+      'colno':   colno,
+      'stack':   error && error.stack
+    }
   })
 }

--- a/app/controllers/ndr_error/client_errors_controller.rb
+++ b/app/controllers/ndr_error/client_errors_controller.rb
@@ -2,23 +2,9 @@ module NdrError
   # Controller for receiving client errors
   class ClientErrorsController < ApplicationController
     def create
-      exception = JavascriptError.new(params[:client_error])
-
-      error_params = params[:client_error]
-      exception    = Exception.new(error_params.delete(:message))
-
-
-      # TODO: this needs to be a separate message
-      fingerprint, log = NdrError.log(exception, {}, request)
-
-      # TODO: set error_class / message separately
-      # TODO: strip 
-      # TODO: don't do this here!
-      log.update_attributes(
-        url: request.env['HTTP_REFERER'],
-        backtrace: (error_params.delete(:stack) || '').split("\n"),
-        parameters_yml: error_params
-      )
+      exception        = JavascriptError.new(params[:client_error])
+      ancillary        = {} # TODO: populate this as the middleware does
+      fingerprint, log = NdrError.log(exception, ancillary, request)
 
       render json: {
         fingerprint: fingerprint.id,

--- a/app/controllers/ndr_error/client_errors_controller.rb
+++ b/app/controllers/ndr_error/client_errors_controller.rb
@@ -1,0 +1,27 @@
+module NdrError
+  # Controller for receiving client errors
+  class ClientErrorsController < ApplicationController
+    def create
+      Rails.logger.info(params.inspect)
+
+      exception  = Exception.new(params[:message])
+      parameters = {}
+
+      # TODO: this needs to be a separate message
+      fingerprint, log = NdrError.log(exception, parameters, request)
+
+      # TODO: set error_class / message separately
+      # TODO: strip 
+      # TODO: don't do this here!
+      log.update_attributes(
+        url: params[:path],
+        backtrace: (params[:stack] || '').split("\n")
+      )
+
+      render json: {
+        fingerprint: fingerprint.id,
+        uuid: log.try(:id)
+      }
+    end
+  end
+end

--- a/app/controllers/ndr_error/client_errors_controller.rb
+++ b/app/controllers/ndr_error/client_errors_controller.rb
@@ -2,20 +2,22 @@ module NdrError
   # Controller for receiving client errors
   class ClientErrorsController < ApplicationController
     def create
-      Rails.logger.info(params.inspect)
+      exception = JavascriptError.new(params[:client_error])
 
-      exception  = Exception.new(params[:message])
-      parameters = {}
+      error_params = params[:client_error]
+      exception    = Exception.new(error_params.delete(:message))
+
 
       # TODO: this needs to be a separate message
-      fingerprint, log = NdrError.log(exception, parameters, request)
+      fingerprint, log = NdrError.log(exception, {}, request)
 
       # TODO: set error_class / message separately
       # TODO: strip 
       # TODO: don't do this here!
       log.update_attributes(
-        url: params[:path],
-        backtrace: (params[:stack] || '').split("\n")
+        url: request.env['HTTP_REFERER'],
+        backtrace: (error_params.delete(:stack) || '').split("\n"),
+        parameters_yml: error_params
       )
 
       render json: {

--- a/app/models/ndr_error/log.rb
+++ b/app/models/ndr_error/log.rb
@@ -116,13 +116,15 @@ module NdrError
       self.error_class = exception.class.to_s
       self.backtrace   = exception.backtrace
       self.description = description_from(exception.message)
+
+      self.parameters_yml = exception.metadata if client_error?
     end
 
     # Stores parameters from the given _request_ object
     # as YAML. Will attempt to store as many as possible
     # of the parameters in the available 4000 chars.
     def register_request(request)
-      extract_request_params(request)
+      extract_request_params(request) unless client_error?
       extract_request_attributes(request)
     end
 
@@ -176,6 +178,10 @@ module NdrError
       @_digest = digest
     end
 
+    def client_error?
+      error_class == 'NdrError::JavascriptError'
+    end
+
     private
 
     # For the given `request' object, return the
@@ -199,9 +205,11 @@ module NdrError
     def extract_request_attributes(request)
       return unless request
 
+      uri = request.env[client_error? ? 'HTTP_REFERER' : 'REQUEST_URI']
+
       self.port       = request.env['SERVER_PORT']
       self.ip         = "#{request.env['REMOTE_ADDR']}/#{request.remote_ip}"
-      self.url        = "#{request.env['REQUEST_URI']} (on #{request.host})"
+      self.url        = "#{uri} (on #{request.host})"
       self.user_agent = request.env['HTTP_USER_AGENT']
     end
 

--- a/app/models/ndr_error/log.rb
+++ b/app/models/ndr_error/log.rb
@@ -153,7 +153,7 @@ module NdrError
     # Returns the params hash associated
     # with the request.
     def parameters
-      YAML.load(parameters_yml)
+      YAML.safe_load(parameters_yml, [Symbol])
     end
 
     # Formats error to be like the ruby error.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,8 @@ NdrError::Engine.routes.draw do
             only: [:index, :show, :edit, :update, :destroy],
             controller: 'errors',
             as: 'error_fingerprints'
+
+  resources :client_errors,
+            only: [:create],
+            controller: 'client_errors'
 end

--- a/lib/ndr_error.rb
+++ b/lib/ndr_error.rb
@@ -3,6 +3,7 @@ require 'ndr_error/engine'
 require 'ndr_error/backtrace_compression'
 require 'ndr_error/finder'
 require 'ndr_error/fuzzing'
+require 'ndr_error/javascript_error'
 require 'ndr_error/logging'
 require 'ndr_error/uuid_builder'
 

--- a/lib/ndr_error/fuzzing.rb
+++ b/lib/ndr_error/fuzzing.rb
@@ -17,6 +17,7 @@ module NdrError
     #   * independent of deployment paths
     #   * independent of line numbers
     def fuzz_backtrace(backtrace)
+      return '' if client_error?
       backtrace.map { |line| fuzz_line(line) }.join("\n")
     end
 

--- a/lib/ndr_error/javascript_error.rb
+++ b/lib/ndr_error/javascript_error.rb
@@ -1,4 +1,6 @@
 module NdrError
+  # Class to wrap / normalise Javascript exception
+  # data, and allow it to be logged by NdrError.
   class JavascriptError < Exception
     attr_reader :source
 

--- a/lib/ndr_error/javascript_error.rb
+++ b/lib/ndr_error/javascript_error.rb
@@ -1,0 +1,23 @@
+module NdrError
+  class JavascriptError < Exception
+    attr_reader :source
+
+    def initialize(parameters)
+      @source = parameters.with_indifferent_access
+
+      super(@source['message'])
+
+      set_backtrace_from_stack
+    end
+
+    def metadata
+      source.except('message', 'stack')
+    end
+
+    private
+
+    def set_backtrace_from_stack
+      set_backtrace @source.fetch('stack', '').split("\n")
+    end
+  end
+end

--- a/lib/ndr_error/logging.rb
+++ b/lib/ndr_error/logging.rb
@@ -6,8 +6,6 @@ module NdrError
 
     # Log the given `exception`.
     def log(exception, ancillary_data, request_object)
-      return log_client_error(exception, ancillary_data, request_object) if exception.client?
-
       log = initialize_log(ancillary_data)
       log.register_exception(exception)
       log.register_request(request_object)
@@ -19,11 +17,6 @@ module NdrError
     end
 
     private
-
-    # Client errors are logged / fingerprinted differently
-    def log_client_error(exception, ancillary_data, request_object)
-      
-    end
 
     # Manual attribute whitelisting:
     def initialize_log(ancillary_data)

--- a/lib/ndr_error/logging.rb
+++ b/lib/ndr_error/logging.rb
@@ -6,6 +6,8 @@ module NdrError
 
     # Log the given `exception`.
     def log(exception, ancillary_data, request_object)
+      return log_client_error(exception, ancillary_data, request_object) if exception.client?
+
       log = initialize_log(ancillary_data)
       log.register_exception(exception)
       log.register_request(request_object)
@@ -17,6 +19,11 @@ module NdrError
     end
 
     private
+
+    # Client errors are logged / fingerprinted differently
+    def log_client_error(exception, ancillary_data, request_object)
+      
+    end
 
     # Manual attribute whitelisting:
     def initialize_log(ancillary_data)

--- a/test/dummy/app/assets/javascripts/application.js
+++ b/test/dummy/app/assets/javascripts/application.js
@@ -12,4 +12,5 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require ndr_error/client_errors
 //= require_tree .

--- a/test/dummy/app/controllers/disaster_controller.rb
+++ b/test/dummy/app/controllers/disaster_controller.rb
@@ -1,9 +1,15 @@
 # Some application logic that we should be able to log failures from:
 class DisasterController < ApplicationController
   def no_panic
+    # Triggers no exceptions
   end
 
   def cause
+    # Triggers a server-side exception
     fail params[:message]
+  end
+
+  def cause_client
+    # Triggers a client-side exception
   end
 end

--- a/test/dummy/app/views/disaster/cause_client.html.erb
+++ b/test/dummy/app/views/disaster/cause_client.html.erb
@@ -1,0 +1,4 @@
+<p>This page should raise a Javascript error</p>
+<script type="text/javascript" charset="utf-8">
+  1 + fooBarBaz;
+</script>

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -10,7 +10,7 @@ Dummy::Application.configure do
   config.whiny_nils = true
 
   # Show full error reports and disable caching
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = false
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send

--- a/test/integration/client_error_logging_test.rb
+++ b/test/integration/client_error_logging_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+# Ensure host app is able to log errors sent to the API endpoint
+class ClientErrorLoggingTest < ActionDispatch::IntegrationTest
+  def setup
+    NdrError::Fingerprint.delete_all
+    NdrError::Log.delete_all
+  end
+
+  test 'should log client exceptions' do
+    assert_difference(-> { NdrError::Log.count }, 2) do
+      2.times { visit '/disaster/cause_client' }
+    end
+
+    error_logs = NdrError::Log.all
+    assert error_logs.map(&:error_fingerprint).uniq.one?
+    error_log = error_logs.first
+
+    assert_equal 'NdrError::JavascriptError', error_log.error_class
+    assert_equal "ReferenceError: Can't find variable: fooBarBaz", error_log.description
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,8 +33,9 @@ end
 Capybara.register_driver :poltergeist do |app|
   options = {
     # debug: true, # Uncomment for more verbose
-    # inspector: true, # DEBUGGING suppport.
+    inspector: true, # DEBUGGING suppport.
     phantomjs_options: ['--proxy-type=none'],
+    js_errors: false,
     timeout: 60
   }
 

--- a/test/unit/ndr_error/fuzzing_test.rb
+++ b/test/unit/ndr_error/fuzzing_test.rb
@@ -18,36 +18,36 @@ module NdrError
 
     test 'should fuzz descriptions correctly' do
       description = "TemplateError: undefined method `clean' for [\"XYZ\", \"ABC\"]:Array"
-      refute @fuzzable.send(:fuzz_description, description).include?('XYZ')
+      refute fuzz_description(description).include?('XYZ')
 
       # Should obfuscate objectids:
-      assert_equal @fuzzable.fuzz('#<EUserBatch:0x123e12345>', []), @fuzzable.fuzz('#<EUserBatch:0x134a45639>', [])
+      assert_equal fuzz('#<EUserBatch:0x123e12345>', []), fuzz('#<EUserBatch:0x134a45639>', [])
     end
 
     test 'should fuzz Rails root directory from backtraces' do
-      trace = @fuzzable.send(:fuzz_backtrace, [Rails.root.join('app').to_s])
+      trace = fuzz_backtrace([Rails.root.join('app').to_s])
       assert_equal 'Rails.root/app', trace
     end
 
     test 'should fuzz gem differences from backtraces' do
       # Should fuzz gem paths:
-      trace = @fuzzable.send(:fuzz_backtrace, [Gem.path.first + '/app'])
+      trace = fuzz_backtrace([Gem.path.first + '/app'])
       assert_equal 'Gem.path/app', trace
 
       # Should remove gem version number when fuzzing gem paths
       line = Gem.path.first + "/gems/evil-1.4.3/lib/evil/file.rb:623:in `method'"
-      assert_equal "Gem.path/gems/evil-/lib/evil/file.rbin `method'", @fuzzable.send(:fuzz_backtrace, [line])
+      assert_equal "Gem.path/gems/evil-/lib/evil/file.rbin `method'", fuzz_backtrace([line])
     end
 
     test 'should fuzz LOAD_PATH from backtraces' do
       # Should fuzz load path entries:
-      trace = @fuzzable.send(:fuzz_backtrace, [$LOAD_PATH.first + '/app'])
+      trace = fuzz_backtrace([$LOAD_PATH.first + '/app'])
       refute trace.include?($LOAD_PATH.first)
     end
 
     test 'should fuzz line numbers from backtraces' do
       # Should fuzz line numbers:
-      trace = @fuzzable.send(:fuzz_backtrace, ['app/myfile.rb:12: in function'])
+      trace = fuzz_backtrace(['app/myfile.rb:12: in function'])
       assert_equal 'app/myfile.rb in function', trace
     end
 
@@ -55,34 +55,48 @@ module NdrError
       template = ActionView::Template.new('test template', 'template.html.erb', nil, {})
       compiled = template.send(:method_name) # The method name of the template once compiled
 
-      assert_equal '_template_html_erb__COMPILED_ID', @fuzzable.send(:fuzz_backtrace, [compiled])
+      assert_equal '_template_html_erb__COMPILED_ID', fuzz_backtrace([compiled])
 
       partial  = ActionView::Template.new('test partial', '_partial.html.erb', nil, {})
       compiled = partial.send(:method_name) # The method name of the partial once compiled
 
-      assert_equal '__partial_html_erb__COMPILED_ID', @fuzzable.send(:fuzz_backtrace, [compiled])
+      assert_equal '__partial_html_erb__COMPILED_ID', fuzz_backtrace([compiled])
     end
 
     test 'should fuzz compiled callbacks from backtraces' do
-      trace = @fuzzable.send(:fuzz_backtrace, ['_run__2058915813__process_action__1931044129__callbacks'])
+      trace = fuzz_backtrace(['_run__2058915813__process_action__1931044129__callbacks'])
       assert_equal '_run__COMPILED_ID__process_action__COMPILED_ID__callbacks', trace
     end
-    
+
     test '#fuzz_backtrace should be consistent with client errors' do
       @fuzzable.stubs(client_error?: true)
-      assert_equal @fuzzable.send(:fuzz_backtrace, ['abc']), @fuzzable.send(:fuzz_backtrace, ['bcd'])
+      assert_equal fuzz_backtrace(['abc']), @fuzzable.send(:fuzz_backtrace, ['bcd'])
     end
 
     test 'fuzzing should be sensitive to client error descriptions' do
       @fuzzable.stubs(client_error?: true)
-      assert_equal @fuzzable.fuzz('test', []), @fuzzable.fuzz('test', [])
-      refute_equal @fuzzable.fuzz('test', []), @fuzzable.fuzz('zest', [])
+      assert_equal fuzz('test', []), fuzz('test', [])
+      refute_equal fuzz('test', []), fuzz('zest', [])
     end
 
     test 'fuzzing should be not sensitive to client error backtraces' do
       @fuzzable.stubs(client_error?: true)
-      assert_equal @fuzzable.fuzz('test', %w(t e s t)), @fuzzable.fuzz('test', %w(t e s t))
-      assert_equal @fuzzable.fuzz('test', %w(t e s t)), @fuzzable.fuzz('test', %w(e s t e))
+      assert_equal fuzz('test', %w(t e s t)), fuzz('test', %w(t e s t))
+      assert_equal fuzz('test', %w(t e s t)), fuzz('test', %w(e s t e))
+    end
+
+    private
+
+    def fuzz_description(string)
+      @fuzzable.send(:fuzz_description, string)
+    end
+
+    def fuzz_backtrace(trace)
+      @fuzzable.send(:fuzz_backtrace, trace)
+    end
+
+    def fuzz(description, backtrace)
+      @fuzzable.fuzz(description, backtrace)
     end
   end
 end

--- a/test/unit/ndr_error/fuzzing_test.rb
+++ b/test/unit/ndr_error/fuzzing_test.rb
@@ -3,40 +3,51 @@ require 'test_helper'
 module NdrError
   # Test our fuzzing / digest creation:
   class FuzzingTest < ActiveSupport::TestCase
-    include NdrError::Fuzzing
+    # Dummy class for testing Fuzzing mixin
+    class Fuzzable
+      include NdrError::Fuzzing
+
+      def client_error?
+        false
+      end
+    end
+
+    def setup
+      @fuzzable = Fuzzable.new
+    end
 
     test 'should fuzz descriptions correctly' do
       description = "TemplateError: undefined method `clean' for [\"XYZ\", \"ABC\"]:Array"
-      refute send(:fuzz_description, description).include?('XYZ')
+      refute @fuzzable.send(:fuzz_description, description).include?('XYZ')
 
       # Should obfuscate objectids:
-      assert_equal fuzz('#<EUserBatch:0x123e12345>', []), fuzz('#<EUserBatch:0x134a45639>', [])
+      assert_equal @fuzzable.fuzz('#<EUserBatch:0x123e12345>', []), @fuzzable.fuzz('#<EUserBatch:0x134a45639>', [])
     end
 
     test 'should fuzz Rails root directory from backtraces' do
-      trace = send(:fuzz_backtrace, [Rails.root.join('app').to_s])
+      trace = @fuzzable.send(:fuzz_backtrace, [Rails.root.join('app').to_s])
       assert_equal 'Rails.root/app', trace
     end
 
     test 'should fuzz gem differences from backtraces' do
       # Should fuzz gem paths:
-      trace = send(:fuzz_backtrace, [Gem.path.first + '/app'])
+      trace = @fuzzable.send(:fuzz_backtrace, [Gem.path.first + '/app'])
       assert_equal 'Gem.path/app', trace
 
       # Should remove gem version number when fuzzing gem paths
       line = Gem.path.first + "/gems/evil-1.4.3/lib/evil/file.rb:623:in `method'"
-      assert_equal "Gem.path/gems/evil-/lib/evil/file.rbin `method'", send(:fuzz_backtrace, [line])
+      assert_equal "Gem.path/gems/evil-/lib/evil/file.rbin `method'", @fuzzable.send(:fuzz_backtrace, [line])
     end
 
     test 'should fuzz LOAD_PATH from backtraces' do
       # Should fuzz load path entries:
-      trace = send(:fuzz_backtrace, [$LOAD_PATH.first + '/app'])
+      trace = @fuzzable.send(:fuzz_backtrace, [$LOAD_PATH.first + '/app'])
       refute trace.include?($LOAD_PATH.first)
     end
 
     test 'should fuzz line numbers from backtraces' do
       # Should fuzz line numbers:
-      trace = send(:fuzz_backtrace, ['app/myfile.rb:12: in function'])
+      trace = @fuzzable.send(:fuzz_backtrace, ['app/myfile.rb:12: in function'])
       assert_equal 'app/myfile.rb in function', trace
     end
 
@@ -44,17 +55,34 @@ module NdrError
       template = ActionView::Template.new('test template', 'template.html.erb', nil, {})
       compiled = template.send(:method_name) # The method name of the template once compiled
 
-      assert_equal '_template_html_erb__COMPILED_ID', send(:fuzz_backtrace, [compiled])
+      assert_equal '_template_html_erb__COMPILED_ID', @fuzzable.send(:fuzz_backtrace, [compiled])
 
       partial  = ActionView::Template.new('test partial', '_partial.html.erb', nil, {})
       compiled = partial.send(:method_name) # The method name of the partial once compiled
 
-      assert_equal '__partial_html_erb__COMPILED_ID', send(:fuzz_backtrace, [compiled])
+      assert_equal '__partial_html_erb__COMPILED_ID', @fuzzable.send(:fuzz_backtrace, [compiled])
     end
 
     test 'should fuzz compiled callbacks from backtraces' do
-      trace = send(:fuzz_backtrace, ['_run__2058915813__process_action__1931044129__callbacks'])
+      trace = @fuzzable.send(:fuzz_backtrace, ['_run__2058915813__process_action__1931044129__callbacks'])
       assert_equal '_run__COMPILED_ID__process_action__COMPILED_ID__callbacks', trace
+    end
+    
+    test '#fuzz_backtrace should be consistent with client errors' do
+      @fuzzable.stubs(client_error?: true)
+      assert_equal @fuzzable.send(:fuzz_backtrace, ['abc']), @fuzzable.send(:fuzz_backtrace, ['bcd'])
+    end
+
+    test 'fuzzing should be sensitive to client error descriptions' do
+      @fuzzable.stubs(client_error?: true)
+      assert_equal @fuzzable.fuzz('test', []), @fuzzable.fuzz('test', [])
+      refute_equal @fuzzable.fuzz('test', []), @fuzzable.fuzz('zest', [])
+    end
+
+    test 'fuzzing should be not sensitive to client error backtraces' do
+      @fuzzable.stubs(client_error?: true)
+      assert_equal @fuzzable.fuzz('test', %w(t e s t)), @fuzzable.fuzz('test', %w(t e s t))
+      assert_equal @fuzzable.fuzz('test', %w(t e s t)), @fuzzable.fuzz('test', %w(e s t e))
     end
   end
 end

--- a/test/unit/ndr_error/javascript_error_test.rb
+++ b/test/unit/ndr_error/javascript_error_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+module NdrError
+  # Unit Test Log.
+  class JavaScriptErrorTest < ActiveSupport::TestCase
+    test 'should set backtrace' do
+      params = {
+        "message"=>"ReferenceError: adfgrdfgkljh is not defined",
+        "source"=>"http://localhost:3000",
+        "lineno"=>"49",
+        "colno"=>"1",
+        "stack"=>
+        "stack_values\nline 1\nline 2\nline 3"
+      }
+      error = JavascriptError.new(params)
+
+      assert_equal "ReferenceError: adfgrdfgkljh is not defined", error.message
+      assert_equal 4, error.backtrace.length
+
+    end
+  end
+end

--- a/test/unit/ndr_error/javascript_error_test.rb
+++ b/test/unit/ndr_error/javascript_error_test.rb
@@ -5,18 +5,16 @@ module NdrError
   class JavaScriptErrorTest < ActiveSupport::TestCase
     test 'should set backtrace' do
       params = {
-        "message"=>"ReferenceError: adfgrdfgkljh is not defined",
-        "source"=>"http://localhost:3000",
-        "lineno"=>"49",
-        "colno"=>"1",
-        "stack"=>
-        "stack_values\nline 1\nline 2\nline 3"
+        'message' => 'ReferenceError: adfgrdfgkljh is not defined',
+        'source'  => 'http://localhost:3000',
+        'lineno'  => '49',
+        'colno'   => '1',
+        'stack'   => "stack_values\nline 1\nline 2\nline 3"
       }
       error = JavascriptError.new(params)
 
-      assert_equal "ReferenceError: adfgrdfgkljh is not defined", error.message
+      assert_equal 'ReferenceError: adfgrdfgkljh is not defined', error.message
       assert_equal 4, error.backtrace.length
-
     end
   end
 end

--- a/test/unit/ndr_error/log_test.rb
+++ b/test/unit/ndr_error/log_test.rb
@@ -394,5 +394,11 @@ module NdrError
         assert_raises(SecurityError) { trigger.call }
       end
     end
+
+    test 'should return metadata if client error' do
+      error = Log.new
+      error.register_exception(JavascriptError.new(message: 'oops', stack: "a\nb\nc", test: 'foobar'))
+      assert_equal({'test' => 'foobar'}, error.parameters)
+    end
   end
 end

--- a/test/unit/ndr_error/log_test.rb
+++ b/test/unit/ndr_error/log_test.rb
@@ -396,9 +396,11 @@ module NdrError
     end
 
     test 'should return metadata if client error' do
-      error = Log.new
-      error.register_exception(JavascriptError.new(message: 'oops', stack: "a\nb\nc", test: 'foobar'))
-      assert_equal({'test' => 'foobar'}, error.parameters)
+      error     = Log.new
+      exception = JavascriptError.new(message: 'oops', stack: "a\nb\nc", test: 'foobar')
+
+      error.register_exception(exception)
+      assert_equal({ 'test' => 'foobar' }, error.parameters)
     end
   end
 end

--- a/test/unit/ndr_error/log_test.rb
+++ b/test/unit/ndr_error/log_test.rb
@@ -96,6 +96,12 @@ module NdrError
       assert_equal({}, error.parameters)
     end
 
+    test 'should safe-load paramaters' do
+      error     = Log.new(parameters_yml: { not: /allowed/ })
+      exception = assert_raises(Psych::DisallowedClass) { error.parameters }
+      assert_match(/Regexp/, exception.message)
+    end
+
     test 'should store the params hash correctly when they fit in the column' do
       params1 = { a: 1 }
       params2 = { b: 2 }


### PR DESCRIPTION
@ollietulloch, @kylenene; we can use this PR to look at what remains to be done.

- [x] add `window.onerror` handler
- [x] add Rails endpoint to receive errors
- [x] distinguish between client errors and Ruby errors (using `JavascriptError`)
- [x] ensure UI works reasonably
- [ ] more UI polish – make browser errors stand out visually?
- [ ] should API endpoint controller be active by default?
- [ ] document how to enable client error logging
- [ ] rate-limit?
- [ ] Investigate `StackTrace` JS library, for better cross-browser support
- [ ] more coverage + RuboCop
