### PR TITLE
tag version v2.3.3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0
+        ruby-version: 3.4
     - name: Install dependencies
       run: bundle install
     - name: Run RuboCop against BASE..HEAD changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,18 +5,28 @@ on: [push]
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
           - '3.0'
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
         gemfile:
           - gemfiles/Gemfile.rails61
           - gemfiles/Gemfile.rails70
           - gemfiles/Gemfile.rails71
           - gemfiles/Gemfile.rails72
+          - gemfiles/Gemfile.rails80
         exclude:
+          # rails 6.1 requires ruby < 3.4
+          - ruby-version: '3.4'
+            gemfile: 'gemfiles/Gemfile.rails61'
+          # rails 7.0 requires ruby >= 2.7, < 3.4
+          # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
+          - ruby-version: '3.4'
+            gemfile: 'gemfiles/Gemfile.rails70'
           # rails 7.2 requires ruby >= 3.1
           # https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html
           - ruby-version: '3.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Fixed
 * Support Ruby 3.4, Rails 8.0
+* Fix ruby 3.4 frozen string literal warnings
 
 ## 2.3.2 / 2024-11-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
-* no unreleased changes
+### Fixed
+* Support Ruby 3.4, Rails 8.0
 
 ## 2.3.2 / 2024-11-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## [Unreleased]
+* no unreleased changes
+
+## 2.3.3 / 2025-11-24
 ### Fixed
-* Support Ruby 3.4, Rails 8.0
-* Fix ruby 3.4 frozen string literal warnings
+* Support Ruby 3.4, Rails 8.0 [backported from v2.4.3]
+* Fix ruby 3.4 frozen string literal warnings [backported from v2.4.3]
 
 ## 2.3.2 / 2024-11-21
 ### Fixed

--- a/app/helpers/ndr_error/errors_helper.rb
+++ b/app/helpers/ndr_error/errors_helper.rb
@@ -11,7 +11,7 @@ module NdrError
 
       error.backtrace.map do |line|
         css_classes = 'trace-item'
-        css_classes << ' stack-only' unless highlighting.include?(line)
+        css_classes += ' stack-only' unless highlighting.include?(line)
 
         content_tag(:span, line, class: css_classes)
       end
@@ -59,7 +59,7 @@ module NdrError
     def ticket_link_for(fingerprint, small = false)
       text = glyphicon_tag('asterisk') + ' View ticket'
       css  = 'btn btn-default'
-      css << ' btn-xs' if small
+      css += ' btn-xs' if small
 
       url = fingerprint.ticket_url
       link_to(text, /^http/i =~ url ? url : "http://#{url}", class: css)
@@ -87,7 +87,7 @@ module NdrError
 
     def previous_button_for(error)
       css = 'btn btn-default'
-      css << ' disabled' if error.nil?
+      css += ' disabled' if error.nil?
       text = glyphicon_tag('chevron-left')
       path = error.nil? ? '#' : error_fingerprint_path(error.error_fingerprint, log_id: error)
 
@@ -96,7 +96,7 @@ module NdrError
 
     def next_button_for(error)
       css = 'btn btn-default'
-      css << ' disabled' if error.nil?
+      css += ' disabled' if error.nil?
       text = glyphicon_tag('chevron-right')
       path = error.nil? ? '#' : error_fingerprint_path(error.error_fingerprint, log_id: error)
 

--- a/gemfiles/Gemfile.rails80
+++ b/gemfiles/Gemfile.rails80
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 8.0.0'

--- a/lib/ndr_error/version.rb
+++ b/lib/ndr_error/version.rb
@@ -2,5 +2,5 @@
 
 # Contains the version of NdrError. Sourced by the gemspec.
 module NdrError
-  VERSION = '2.3.2'
+  VERSION = '2.3.3'
 end

--- a/ndr_error.gemspec
+++ b/ndr_error.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.0'
 
-  s.add_dependency 'rails', '>= 6.1', '< 7.3'
+  s.add_dependency 'rails', '>= 6.1', '< 8.1'
 
   # Support rails 6.1 with Ruby 3.1
   s.add_dependency 'net-imap'

--- a/ndr_error.gemspec
+++ b/ndr_error.gemspec
@@ -45,6 +45,13 @@ Gem::Specification.new do |s|
   # https://bugs.ruby-lang.org/issues/19371
   s.add_development_dependency 'psych', '< 5'
 
+  # Workaround build issue on GitHub Actions with ruby <= 3.1 when installing sass-embedded
+  # Versions 1.77.0 and above require ruby >= 3.2 for packaged x86_64-linux binaries
+  # but say they're compatible with ruby 3.1.
+  # 1.76.0 has a bug that was fixed in 1.77.1, which we can't use yet.
+  # https://github.com/sass/dart-sass/issues/2239
+  s.add_development_dependency 'sass-embedded', '~> 1.75.0' if RUBY_VERSION.start_with?('3.1') # rubocop:disable Gemspec/RubyVersionGlobalsUsage
+
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'test-unit', '~> 3.0'
 


### PR DESCRIPTION
Back-port Ruby 3.4 and Rails 8.0 support from v2.4.3 (which Bootstrap 5) to a new v2.3.* release (Bootstrap 3).

This PR has conflicts with the `main` branch (as expected). Once this PR is approved and the new gem is released, I'll create a separate merge PR to cleanly merge this to the `main` branch.